### PR TITLE
Add support for Laravel 5.5

### DIFF
--- a/src/Commands/MigrationCommand.php
+++ b/src/Commands/MigrationCommand.php
@@ -115,6 +115,16 @@ class MigrationCommand extends Command
 
         }
     }
+    
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->fire();
+    }
 
     /**
      * Create the migration.


### PR DESCRIPTION
On Laravel 5.5 uses `handle()` method instead of `fire()`